### PR TITLE
Adding support for Hapi 6.x

### DIFF
--- a/lib/app/getPackageFile.js
+++ b/lib/app/getPackageFile.js
@@ -39,7 +39,7 @@ var deps = {
         "semi-static": "0.0.5"
     },
     hapi: {
-        "hapi": "2.x.x",
+        "hapi": "6.x.x",
         "moonboots_hapi": "2.x.x"
     }
 };

--- a/template/hapi/server.js
+++ b/template/hapi/server.js
@@ -25,7 +25,7 @@ server.ext('onPreResponse', function(request, reply) {
 
 
 // require moonboots_hapi plugin
-server.pack.require({'moonboots_hapi': moonbootsConfig}, function (err) {
+server.pack.register({plugin: require('moonboots_hapi'), options: moonbootsConfig}, function (err) {
     if (err) throw err;
     server.pack.register(fakeApi, function (err) {
         if (err) throw err;


### PR DESCRIPTION
Just a couple updates to make compatible with the latest major version of Hapi. If there were other reasons to hold it at 2.x.x let me know and I can add backwards compatibility. 
