### PR TITLE
update main.js to properly set document title

### DIFF
--- a/template/shared/client/views/main.js
+++ b/template/shared/client/views/main.js
@@ -31,7 +31,7 @@ module.exports = View.extend({
         this.pageSwitcher = new ViewSwitcher(this.getByRole('page-container'), {
             show: function (newView, oldView) {
                 // it's inserted and rendered for me
-                document.title = _.result(newView.pageTitle) || "{{{title}}}";
+                document.title = _.result(newView, 'pageTitle') || "{{{title}}}";
                 document.scrollTop = 0;
 
                 // add a class specifying it's active


### PR DESCRIPTION
The pageTitle was never being updated even though `pageTitle` is set in all views.

updated the args to `_.result` to pick up the pageTitle attribute from the view.
