### PR TITLE
Updated Hapi template to honor the configured http listen option.

### DIFF
--- a/template/hapi/server.js
+++ b/template/hapi/server.js
@@ -1,6 +1,6 @@
 var Hapi = require('hapi');
 var config = require('getconfig');
-var server = new Hapi.Server('localhost', config.http.port);
+var server = new Hapi.Server(config.http.listen, config.http.port);
 var moonbootsConfig = require('./moonbootsConfig');
 var fakeApi = require('./fakeApi');
 var internals = {};


### PR DESCRIPTION
The Hapi template was hardcoded to `'localhost'` rather than using the configured `listen` property of the `http` configuration.
