### PR TITLE
Rename numberRequired to minLength on ArrayInputView template

### DIFF
--- a/lib/templates/array-input.js
+++ b/lib/templates/array-input.js
@@ -2,6 +2,6 @@ new ArrayInputView({
     label: '{{{ label }}}',
     name: '{{{ name }}}',
     value: this.model.{{{ name }}} || [],
-    numberRequired: 0,
+    minLength: 0,
     parent: this
 })


### PR DESCRIPTION
Rename numberRequired to minLength so it works with ampersand-array-input-view >= 2.0.0

https://github.com/AmpersandJS/ampersand-array-input-view/commit/8806fb08a206380f2097274a4ee4d978da029b4c#diff-8d634bcc6ae9fbf6b738528eb19bdd3aL66
