### PR TITLE
Checks if the default is not already prevented in the link click event

### DIFF
--- a/template/shared/client/views/main.js
+++ b/template/shared/client/views/main.js
@@ -63,7 +63,7 @@ module.exports = View.extend({
 
         // if it's a plain click (no modifier keys)
         // and it's a local url, navigate internally
-        if (local && !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
+        if (local && !e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && !e.defaultPrevented) {
             e.preventDefault();
             app.navigate(aTag.pathname);
         }


### PR DESCRIPTION
If we're preventing the default of a local link, we won't want to call navigate. 
This could be solved calling stopPropagation on the other handler, but then we'll potentially lose behaviour. (needed this when using a bootstrap dropdown, handling the click on the options which are a tags)
