### PR TITLE
Fix typo in router.js template.

### DIFF
--- a/lib/templates/router.js
+++ b/lib/templates/router.js
@@ -10,4 +10,4 @@ module.exports = Router.extend({
     home: function () {
         // this.trigger('newPage', new HomePage());
     }
-}};
+});


### PR DESCRIPTION
There was an errant `}`, now it's a `)`. Caught it when running `ampersand gen router foo`.
