### PR TITLE
fix question name for express - `framework`

### DIFF
--- a/lib/app/wizard.js
+++ b/lib/app/wizard.js
@@ -40,7 +40,7 @@ module.exports = function (config) {
         },
         {
             type: 'list',
-            name: 'serverFramework',
+            name: 'framework',
             message: 'Do you want to use hapi or express as a server framework?',
             default: config.framework || 'hapi',
             choices: ['hapi', 'express']


### PR DESCRIPTION
For some reason, the question **name** for the server framework was changed from "framework" to "serverFramework". The question name dictates the key in the result, which in turn must match [generateApp](https://github.com/AmpersandJS/ampersand/blob/master/lib/app/generateApp.js#L27) as "framework".
