### PR TITLE
Form input: handle empty model (Fixes #97)

### DIFF
--- a/lib/templates/input.js
+++ b/lib/templates/input.js
@@ -1,7 +1,7 @@
 new InputView({
     label: '{{{ label }}}',
     name: '{{{ name }}}',
-    value: this.model.{{{ name }}} || '',
+    value: this.model && this.model.{{{ name }}},
     required: {{{ required }}},
     placeholder: '{{{ label }}}',
     parent: this


### PR DESCRIPTION
Prevents a `TypeError: this.model is null` error when adding a new record.
Now uses the same format as what is used in the demo app in `template/shared/client/forms/person.js`.