### PR TITLE
Handle click on element (e.g. <span>) within an anchor <a>

### DIFF
--- a/template/shared/client/views/main.js
+++ b/template/shared/client/views/main.js
@@ -59,6 +59,9 @@ module.exports = View.extend({
 
     handleLinkClick: function (e) {
         var aTag = e.target;
+        if (aTag.nodeName !== 'A' && aTag.parentNode.nodeName == 'A') {
+            aTag = aTag.parentNode;
+        }
         var local = aTag.host === window.location.host;
 
         // if it's a plain click (no modifier keys)


### PR DESCRIPTION
Without this addition, in the example below the element that is clicked is the span, thus it has no `host` property. The link is thus considered not to be local, meaning that `app.navigate` is not used and the browser sends a new `GET` request to the server.
Now if the element is not an anchor, it will check if the parent is one, and use that as the link instead.

```
<div class="list-group" data-hook="blabla-list">
    <a class="blabla list-group-item" data-hook="url" href="/some_url/1">
        <img height="40" width="40" data-hook="avatar" src="some image"></img>
        <span data-hook="name">Some text</span>
    </a>
[...]
```