### PR TITLE
Handle long lines on small screen width

### DIFF
--- a/template/shared/templates/includes/person.jade
+++ b/template/shared/templates/includes/person.jade
@@ -1,4 +1,4 @@
-li.person.list-group-item
+li.person.list-group-item.container
   img(data-hook="avatar", width="40", height="40")
   a(data-hook="name")
   span.btn-group.pull-right 


### PR DESCRIPTION
Adding the `container` class from [Bootstrap](http://getbootstrap.com/css/#grid) to properly handled longer lines.
Without this, if a line gets longer the buttons are pushed to the bottom, but the height of the list item doesn't adapt more than what the text would need. See before and after screenshots made with the default CLI-generated app, and adding just a couple of persons with a long name:

![before](https://cloud.githubusercontent.com/assets/229379/6323443/7677a4f6-bb2a-11e4-8681-81c2effcd034.png)

![after](https://cloud.githubusercontent.com/assets/229379/6323444/7967ceb6-bb2a-11e4-9953-eba66938462f.png)

I agree this specific example (people with rather long names) seems a bit silly, but since this file is used as the base of real applications which can have lines longer than just 2 words, it makes sense to have this included in the sample template.