### PR TITLE
Use amp modules instead of underscore in templates

### DIFF
--- a/lib/app/templatePackage.json
+++ b/lib/app/templatePackage.json
@@ -14,6 +14,9 @@
     "ampersand-router": "^1.0.1",
     "ampersand-view": "^7.0.1",
     "ampersand-view-switcher": "^1.0.2",
+    "amp-bind": "^1.0.1",
+    "amp-result": "^1.1.0",
+    "amp-each": "^1.1.0",
     "async": "^0.9.0",
     "clientconfig": "^1.0.0",
     "domready": "^1.0.5",
@@ -22,8 +25,7 @@
     "getconfig": "^1.0.0",
     "local-links": "^1.2.0",
     "stylizer": "^1.0.0",
-    "templatizer": "^1.0.0",
-    "underscore": "^1.6.0"
+    "templatizer": "^1.0.0"
   },
   "devDependencies": {
   },

--- a/template/shared/client/app.js
+++ b/template/shared/client/app.js
@@ -1,5 +1,5 @@
 var app = require('ampersand-app');
-var _ = require('underscore');
+var bind = require('amp-bind')
 var config = require('clientconfig');
 var Router = require('./router');
 var MainView = require('./views/main');
@@ -42,4 +42,4 @@ app.extend({
 });
 
 // run it on domReady
-domReady(_.bind(app.init, app));
+domReady(bind(app.init, app));

--- a/template/shared/client/pages/base.js
+++ b/template/shared/client/pages/base.js
@@ -1,7 +1,7 @@
 /*global $*/
 // base view for pages
 var View = require('ampersand-view');
-var _ = require('underscore');
+var each = require('amp-each');
 //var key = require('keymaster');
 
 
@@ -10,7 +10,7 @@ module.exports = View.extend({
     registerKeyboardShortcuts: function () {
         /*
         var self = this;
-        _.each(this.keyboardShortcuts, function (value, k) {
+        each(this.keyboardShortcuts, function (value, k) {
             // register key handler scoped to this page
             key(k, self.cid, _.bind(self[value], self));
         });

--- a/template/shared/client/views/main.js
+++ b/template/shared/client/views/main.js
@@ -5,7 +5,7 @@ var setFavicon = require('favicon-setter');
 var View = require('ampersand-view');
 var dom = require('ampersand-dom');
 var ViewSwitcher = require('ampersand-view-switcher');
-var _ = require('underscore');
+var result = require('amp-result');
 var domify = require('domify');
 var localLinks = require('local-links');
 var templates = require('../templates');
@@ -32,7 +32,7 @@ module.exports = View.extend({
         this.pageSwitcher = new ViewSwitcher(this.queryByHook('page-container'), {
             show: function (newView, oldView) {
                 // it's inserted and rendered for me
-                document.title = _.result(newView, 'pageTitle') || '{{{title}}}';
+                document.title = result(newView, 'pageTitle') || '{{{title}}}';
                 document.scrollTop = 0;
 
                 // add a class specifying it's active


### PR DESCRIPTION
I was using the cli generator to start a project tonight and realized you were using underscore instead of your amp modules. This swaps those out.

There might be a reason for that, but I thought I'd submit a PR anyway. 