### PR TITLE
Modify model gen to use collectionfolder configuration value

### DIFF
--- a/lib/generate-template.js
+++ b/lib/generate-template.js
@@ -15,6 +15,8 @@ module.exports = function (config) {
     var name = config._[2];
     var filePath;
     var folderPath;
+    var collectionPath;
+    var collectionToModelPath;
     var file;
     var fileName;
 
@@ -31,7 +33,9 @@ module.exports = function (config) {
     } else if (type === 'model') {
         if (!name) quit('please specify a name: ampersand gen model ' + chalk.magenta('${your model name}'));
         folderPath = path.join(config.approot, config.clientfolder, config.modelfolder);
+        collectionPath = path.join(config.approot, config.clientfolder, config.collectionfolder);
         filePath = path.join(folderPath, fileName);
+        collectionToModelPath = path.join(path.relative(collectionPath, folderPath), name).replace(/\\/g, '/');
     } else if (type === 'view') {
         if (!name) quit('please specify a name: ampersand gen view ' + chalk.magenta('${your view name}'));
         folderPath = path.join(config.approot, config.clientfolder, config.viewfolder);
@@ -56,9 +60,10 @@ module.exports = function (config) {
             }
             if (type === 'model') {
                 config.name = name;
+                config.collectionToModelPath = collectionToModelPath;
                 genTypes.model(config, function (err, result) {
                     var modelFilePath = path.join(config.folderPath, result.modelFileName);
-                    var collectionFilePath = path.join(config.folderPath, result.collectionFileName);
+                    var collectionFilePath = path.join(collectionPath, result.collectionFileName);
                     fsExtra.createFileSync(modelFilePath);
                     fs.writeFileSync(modelFilePath, clean(result.model, config), 'utf8');
                     console.log('\nnew ' + chalk.magenta('Model') + ' created as ' + chalk.magenta(path.relative(process.cwd(), modelFilePath)));

--- a/lib/templates/collection.js
+++ b/lib/templates/collection.js
@@ -1,6 +1,6 @@
 // {{{ name }}} Collection - {{{ collectionFileName }}}.js
 var AmpCollection = require('ampersand-rest-collection');
-var {{{ name }}} = require('./{{{ fileName }}}');
+var {{{ name }}} = require('{{{ collectionToModelPath }}}');
 
 
 module.exports = AmpCollection.extend({


### PR DESCRIPTION
I've just started using AmpersandJS, but one of the things I've noticed is that by default, models and collections are generated in the same folder. In the readme, it is stated that the `collectionfolder` attribute can be used in the project configuration to specify the collection folder (model folder by default), but the generation doesn't appear to factor this in, nor does the attribute seem to be used anywhere in ampersand.

This change should factor in the `collectionfolder` attribute when creating the collection file, and the require path to the model inside of the collection source should automatically adapt relative to where the collection and model are placed. This could probably be done more gracefully, but this was a kind of quick change to assist with my organization preferences while generating models and collections.